### PR TITLE
Finalizada funcionalidad abrir movimiento

### DIFF
--- a/app/Http/Controllers/Cxc/MovController.php
+++ b/app/Http/Controllers/Cxc/MovController.php
@@ -229,6 +229,7 @@ class MovController extends Controller {
 		return view('cxc.movement.mov',compact('mov','clientBalance','movTypeList','currencyList','paymentTypeList','user','officeName'));
 	}
 
+
 	/*public function search($movID, $searchType){
 
 		if($searchType == 'cliente'){
@@ -256,7 +257,8 @@ class MovController extends Controller {
 	}
 
 	public function getListaMovimientos(){
-		$movList = Cxc::all();
+		//$movList = Cxc::all();
+		$movList = Cxc::where('Mov', 'Cobro')->orWhere('Mov', 'Anticipo')->get();
 		//$movList->emission_date = $movList->emission_date->format('d/M/Y');
 
 		return response()->json($movList);
@@ -267,6 +269,27 @@ class MovController extends Controller {
 		$dataURL = '/cxc/movimiento/lista-movimientos/';
 		
 		return view('cxc.movement.open', compact('searchType','dataURL'));
+	}
+
+
+	public function postOpenSelectedMov(){
+		
+
+		//$cxc = Cxc::findOrFail($movID);
+
+		$validator = \Validator::make(\Input::only('movID'), [
+			'movID' => 'required',
+		]);
+
+		if($validator->fails()){
+			return Response::back()->withErrors(['movID','Se requiere seleccionar un movimiento.']);
+		}
+
+		$movID = \Input::get('movID');
+
+		//$cxc->save();
+
+		return redirect('cxc/movimiento/mov/'.$movID);
 	}
 
 	public function postSaveMovementReference($movID){

--- a/resources/views/cxc/movement/open.blade.php
+++ b/resources/views/cxc/movement/open.blade.php
@@ -2,6 +2,7 @@
 
 @section('table-header')
     <th data-field="state" data-radio="true"></th>
+    <th data-field="ID" data-align="right" data-sortable="true" data-visible="false">ID</th>
     <th data-field="MovID" data-align="right" data-sortable="true">MovID</th>
     <th data-field="Mov" data-align="center" data-sortable="true">Movimiento</th>
     <th data-field="concept" data-sortable="true">Concepto</th>
@@ -12,7 +13,7 @@
 @endsection
 
 @section('action')
-	<form id="searchMovForm" class="form-horizontal" role="form" method="POST" action="{{ url('cxc/movimiento/save-mov') }}">
+	<form id="searchMovForm" class="form-horizontal" role="form" method="POST" action="{{ url('cxc/movimiento/open-selected-mov') }}">
 		<input type="hidden" name="_token" value="{{ csrf_token() }}">
 		<input type="hidden" name="movID" id="movID" value="">
 	</form>
@@ -29,7 +30,7 @@
 				return;
 			}
 			
-			$('#movID').val(selections[0].MovID);
+			$('#movID').val(selections[0].ID);
 			$('#searchMovForm').submit();
 		});
 	</script>


### PR DESCRIPTION
Creada la funcion para abrir el movimiento seleccionado, Cambiada la
funcion getListMovimientos para que solo obtenga los movimientos de tipo
"Cobro" o "Anticipo", cambiado el nombre de la funciona en la vista,
agregado el ID del movimiento en un campo escondido y se obtiene el ID
de la selección en lugar de MovID
