### PR TITLE
Correcion de formas de pago no soportadas

### DIFF
--- a/app/Cxc.php
+++ b/app/Cxc.php
@@ -658,16 +658,29 @@ class Cxc extends Model {
 	public function getChangeAllowed(){
 		$charges = $this->getCharges();
 		$paymentTypeListChangeAllowed = json_decode(PaymentType::getPaymentTypeChangeAllowed(),true);
-		$totalChangeAllowedAmount = 0; 
+		$totalChangeAllowedAmount = 0;
+		$paymentTypeList = json_decode(PaymentType::getPaymentTypeList());
 		//dd($charges);
 		for ($i=0; $i < count($charges); $i++) { 
 			if($charges[$i] && $charges[$i]['payment_type']){
 				//dd($paymentTypeListChangeAllowed);
 				//dd($charges[$i]['payment_type']);
 				//dd((bool)$paymentTypeListChangeAllowed[$charges[$i]['payment_type']]);
-				if((bool)$paymentTypeListChangeAllowed[$charges[$i]['payment_type']]){
-					$totalChangeAllowedAmount += $charges[$i]['amount'];
+
+				//$key = array_search($charges[$i]['payment_type'], array_column($paymentTypeList,'payment_type'));
+				//echo($key);
+
+				foreach ($paymentTypeList as $paymentType) {
+					
+					if($charges[$i]['payment_type'] == $paymentType->payment_type){
+						if((bool)$paymentTypeListChangeAllowed[$charges[$i]['payment_type']]){
+							$totalChangeAllowedAmount += $charges[$i]['amount'];
+						}
+					}
 				}
+				/*if((bool)$paymentTypeListChangeAllowed[$charges[$i]['payment_type']]){
+					$totalChangeAllowedAmount += $charges[$i]['amount'];
+				}*/
 			}
 		}
 		//dd($totalChangeAllowedAmount);

--- a/app/Http/Controllers/Cxc/MovController.php
+++ b/app/Http/Controllers/Cxc/MovController.php
@@ -357,6 +357,7 @@ class MovController extends Controller {
 		$currencyList = Mon::getCurrencyList();
 		$paymentTypeList = PaymentType::getPaymentTypeList();
 		$paymentTypeListChangeAllowed = PaymentType::getPaymentTypeChangeAllowed();
+		//if($mov->status =)
 		$totalChangeAllowedAmount = $mov->getChangeAllowed();
 		
 		$movCharges = json_encode($mov->getCharges());

--- a/resources/views/js/cxc/movement/new.blade.php
+++ b/resources/views/js/cxc/movement/new.blade.php
@@ -274,9 +274,10 @@ function addChargeRow(charge){
 			"</div>" +
 			"<div class='col-sm-4'>" +
 				"<label for='charge_type"+chargeNumber+"'>Forma Cobro</label>"+
-				"<select id='charge_type"+chargeNumber+"' name='charge_type"+chargeNumber+"' class='form-control input-sm' disabled='true'>"+
+				"<input type='text' class='form-control input-sm' id='charge_type"+chargeNumber+"' name='charge_type"+chargeNumber+"' value='"+ (charge.payment_type || '') +"' readonly>"+
+				/*"<select id='charge_type"+chargeNumber+"' name='charge_type"+chargeNumber+"' class='form-control input-sm' disabled='true'>"+
 					options +
-				"</select>" +
+				"</select>" +*/
 			"</div>" +
 			"<div class='col-sm-3'>" +
 				"<label for='reference"+chargeNumber+"'>Referencia</label>"+


### PR DESCRIPTION
Cuando se abre una forma de pago no soportada en la terminal movil de un
movimiento sin afectar, la forma de pago de ese cobro aparece vacia, si
esta en otro estado que no sea sin afectar, aparece la forma de cobro
que trae
