### PR TITLE
Métodos modelo Dinero

### DIFF
--- a/app/CorteCaja/CtaDinero.php
+++ b/app/CorteCaja/CtaDinero.php
@@ -42,4 +42,14 @@ class CtaDinero extends Model {
 		'Estatus',
 	];
 
+	const TIPO_CAJA = 'Caja';
+	const TIPO_BANCO = 'Banco';
+
+	/**
+     * Obtiene el modelo de la moneda asociada a la cuenta de dinero.
+     */
+    public function mon()
+    {
+        return $this->hasOne('App\Mon','Moneda','Moneda')->select(['TipoCambio']);
+    }
 }

--- a/app/CorteCaja/Dinero.php
+++ b/app/CorteCaja/Dinero.php
@@ -1,6 +1,7 @@
 <?php namespace App\CorteCaja;
 
 use Illuminate\Database\Eloquent\Model;
+use App\EmpresaConcepto;
 
 class Dinero extends Model {
 
@@ -18,7 +19,11 @@ class Dinero extends Model {
 	 *
 	 * @var array
 	 */
-	protected $fillable = [];
+	protected $fillable = [
+		'CtaDineroDestino',
+		'Importe',
+		'FormaPago',
+	];
 
 	/**
 	 * The attributes that should be casted to native types.
@@ -26,7 +31,9 @@ class Dinero extends Model {
 	 * @var array
 	 */
 	protected $casts = [
-	    'Saldo' => 'float',
+        'ID' => 'integer',
+	    'Importe' => 'float',
+        'TipoCambio' => 'integer',
 	];
 
 	/**
@@ -50,11 +57,274 @@ class Dinero extends Model {
 		'Directo',
 		'CtaDinero',
 		'CtaDineroDestino',
-		'Desglose',
 		'Importe',
 		'FormaPago',
 		'Sucursal',
 		'FechaRegistro'
 	];
 
+    const MODULO_TESORERIA = 'DIN';
+
+    static $COLUMN_NAMES = [
+        'ID',
+        'Empresa',
+        'Mov',
+        'MovID',
+        'FechaEmision',
+        'UltimoCambio',
+        'Concepto',
+        'Moneda',
+        'TipoCambio',
+        'Referencia',
+        'Usuario',
+        'Estatus',
+        'Directo',
+        'CtaDinero',
+        'CtaDineroDestino',
+        'Importe',
+        'FormaPago',
+        'Sucursal',
+        'FechaRegistro'
+    ];
+
+	/**
+     * Obtiene el modelo de la cuenta de dinero asociada al movimiento.
+     */
+    public function ctaDin()
+    {
+        return $this->hasOne('App\CorteCaja\CtaDinero','CtaDinero','CtaDinero')->select(['Tipo','Moneda']);
+    }
+
+    /**
+     * Obtiene el modelo de la cuenta de dinero destino asociada al movimiento.
+     */
+    public function ctaDinDestino()
+    {
+        return $this->hasOne('App\CorteCaja\CtaDinero','CtaDinero','CtaDineroDestino')->select(['Tipo','Moneda']);
+    }
+
+    /**
+     * Obtiene el modelo de la forma de pago asociada al movimiento.
+     */
+    public function formaPago()
+    {
+        return $this->hasOne('App\PaymentType','FormaPago','FormaPago');
+    }
+
+    /**
+     * Obtiene el modelo de la Moneda asociada al movimiento.
+     */
+    public function mon()
+    {
+        return $this->hasOne('App\Mon','Moneda','Moneda')->select(['Moneda','TipoCambio']);
+    }
+
+    /*
+     * Obtiene el tipo de cuenta destino.
+     */
+    public function getTipoCtaDinDestinoAttribute(){
+
+    	$tipoCtaDinero = null;
+    	$ctaDinDestino = $this->ctaDinDestino;
+
+    	if($ctaDinDestino){
+    		$tipoCtaDinero = $ctaDinDestino->Tipo;
+    	}
+
+    	return $tipoCtaDinero;
+    }
+
+    /*
+     * Obtiene el tipo de movimiento (Mov) que se va a
+     * generar dependiendo del tipo de cuenta destino.
+     */
+    public function getTipoMovimientoAttribute(){
+
+    	$tipoMovimiento = null;
+    	$tipoCtaDinDestino = strtolower($this->tipo_cta_din_destino);
+
+    	/*if(!$tipoCtaDinDestino){
+    		return null;
+    	}
+
+    	if($tipoCtaDinDestino == CtaDinero::TIPO_CAJA){
+    		$tipoMovimiento = config('cortecaja.mov_corte_en_caja');
+    	}
+    	else if($tipoCtaDinDestino == CtaDinero::TIPO_BANCO){
+    		$tipoMovimiento = config('cortecaja.mov_corte_en_banco');
+    	}*/
+
+    	if($tipoCtaDinDestino){
+    		$tipoMovimiento = config('cortecaja.mov_corte_en_'.$tipoCtaDinDestino);
+    	}
+
+    	return $tipoMovimiento;
+    }
+
+    /*
+     * Obtiene el concepto por omisión del movimiento
+     * dependiendo del tipo de la empresa(Empresa) y movimiento(Mov).
+     */
+    public function getConceptoOmisionAttribute(){
+
+    	/*$concepto = null;
+    	$mov = strtolower($this->Mov);
+    	$mov = str_replace(' ', '_', $mov);
+
+    	if($mov){
+    		$concepto = config('cortecaja.concepto_'.$mov);
+    	}
+
+    	return $concepto;*/
+
+        $concepto = null;
+        $empresa = $this->Empresa;
+        $modulo = self::MODULO_TESORERIA;
+        $mov = $this->Mov;
+
+        $empresaConcepto = EmpresaConcepto::findByPk($empresa, $modulo, $mov, ['Concepto']);
+        
+        if($empresaConcepto){
+            $concepto = $empresaConcepto->Concepto;
+        }
+
+        return $concepto;
+    }
+
+    /*
+     * Obtiene el modelo de la moneda de la cuenta destino.
+     */
+    public function getMonedaCtaDinDestinoAttribute(){
+
+    	$moneda = null;
+    	$ctaDinDestino = $this->ctaDinDestino;
+
+    	if($ctaDinDestino){
+    		$moneda = $ctaDinDestino->mon;
+    	}
+
+    	return $moneda;
+    }
+
+    /*
+     * Obtiene el tipo de cambio de la moneda.
+     */
+    public function getTipoCambioMonAttribute(){
+
+        $tipoCambio = null;
+        $moneda = $this->mon;
+
+        if($moneda){
+            $tipoCambio = $moneda->TipoCambio;
+        }
+
+        return $tipoCambio;
+    }
+
+    /*
+     * Obtiene el tipo de cambio de la cuenta destino.
+     */
+    public function getTipoCambioCtaDestinoAttribute(){
+
+        $tipoCambio = null;
+        $moneda = $this->moneda_cta_din_destino;
+
+        if($moneda){
+            $tipoCambio = $moneda->TipoCambio;
+        }
+
+        return $tipoCambio;
+    }
+
+    /*
+     * Afecta el movimiento.
+     * @return array
+     *      [0] Código de mensaje
+     *      [1] Descripción del mensaje
+     *      [2] Tipo de mensaje ( AUTORIZACION, CFG, ERROR, INFO, INFORMACION, PRECAUCION )
+     *      [3] Referencia
+     */
+    public function afectar($usuario, $accion = 'Afectar'){
+
+        $modulo = self::MODULO_TESORERIA;
+        $movID = $this->ID;
+        $result = [];
+        
+        if( !$usuario ){
+            $result[] = ['','Se requiere un usuario para '.$accion.'.','ERROR',''];
+            return $result;
+        }
+
+        /* 
+         * Cambia el modo de obtener el resultado, debido a que el sp devuelve columnas sin nomnbres. 
+         * Se obtiene un array con el número de columna como índices.
+         */
+        \DB::connection()->setFetchMode(\PDO::FETCH_NUM);
+
+        $consulta = 'EXECUTE spAfectar ?, ?, ?, NULL, NULL, ?, 1, 0';
+        $parametros = [
+            $modulo,
+            $movID,
+            $accion,
+            $usuario
+        ];
+
+        // Ejecuta el spAfectar y obtiene el resultado.
+        $result = \DB::select( $consulta, $parametros);
+
+
+        return $result[0];
+    }
+
+
+    public function crearMensaje(array $parametros){
+
+        $codigo     = $parametros[0];
+        $descripcion= $parametros[1];
+        $tipo       = $parametros[2]; // [2] Tipo de mensaje ( AUTORIZACION, CFG, ERROR, INFO, INFORMACION, PRECAUCION )
+        $referencia = $parametros[3];
+
+        $mov   = $this->Mov;
+        $movID = $this->MovID;
+
+        $mensaje = new \stdClass();
+        
+        if($codigo == null){
+            $mensaje->tipo = 'success';
+            $mensaje->mensaje = $mov.' afectado.';
+        }
+        else{
+            switch ($tipo) {
+                case 'INFO':
+                case 'INFORMACION':
+                    $mensaje->tipo = 'info';
+                    break;
+                case 'PRECAUCION':
+                    $mensaje->tipo = 'warning';
+                    break;
+                case 'AUTORIZACION':
+                case 'ERROR':
+                case 'CFG':
+                    $mensaje->tipo = 'danger';
+                    break;
+                default:
+                    $mensaje->tipo = 'info';
+                    break;
+            }
+            
+            $mensaje->mensaje = '';
+
+            if($codigo){
+                $mensaje->mensaje .= '('.$codigo.') ';
+            }
+            if($descripcion){
+                $mensaje->mensaje .= $descripcion;
+            }
+            if($referencia){
+                $mensaje->mensaje .= '<BR>'.$referencia;
+            }
+        }
+
+        return $mensaje;
+    }
 }

--- a/app/EmpresaConcepto.php
+++ b/app/EmpresaConcepto.php
@@ -1,0 +1,43 @@
+<?php namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EmpresaConcepto extends Model {
+
+	//protected $primaryKey = 'CtaDinero'; Empresa, Modulo, Mov
+
+	/**
+	 * The database table used by the model.
+	 *
+	 * @var string
+	 */
+	protected $table = 'EmpresaConcepto';
+
+	/**
+	 * The attributes included from the model's JSON form.
+	 *
+	 * @var array
+	 */
+	protected $visible = ['Concepto','Requerido'];
+
+	/**
+	 * The attributes that should be casted to native types.
+	 *
+	 * @var array
+	 */
+	protected $casts = [
+        'Requerido' => 'boolean',
+	];
+
+	public static function findByPk($empresa, $modulo, $mov, array $columns = array('*')){
+
+		return self::where('Empresa',$empresa)
+					->where('Modulo',$modulo)
+					->where('Mov',$mov)
+					->whereNotNull('Empresa')
+					->whereNotNull('Modulo')
+					->whereNotNull('Mov')
+					->select($columns)
+					->first();
+	}
+}

--- a/app/Http/Controllers/CorteCaja/CorteCajaController.php
+++ b/app/Http/Controllers/CorteCaja/CorteCajaController.php
@@ -35,7 +35,117 @@ class CorteCajaController extends Controller {
 
 		$din = new Dinero;
 
-		return view('corteDeCaja.corteCaja', compact('saldo','paymentTypeList'));
+		
+		return view('corteDeCaja.corteCaja', compact('din','saldo','paymentTypeList'));
+	}
+
+	public function postGuardar(){
+
+		$dineroID = \Input::get('ID');
+		
+		$dinero = Dinero::findOrNew($dineroID);
+
+		if($dinero->status && $dinero->status != 'SINAFECTAR'){
+			return redirect()->back()->withInput()->withErrors([
+				'Status'=>'Solo puedes guardar movimientos con estatus \'SINAFECTAR\'.',
+			]);
+		}
+
+		$dineroInput = \Input::all();
+
+		$validator = \Validator::make($dineroInput, [
+			'Importe' => 'required',
+			'CtaDineroDestino' => 'required|exists:CtaDinero,CtaDinero',
+			'FormaPago' => 'required|exists:FormaPago,FormaPago,CxcWeb,1',
+		],
+		[
+			'Importe.required'			=>'Es necesario ingresar el Depósito.',
+			'CtaDineroDestino.required'	=>'Es necesario seleccionar la Cuenta Destino.',
+			'FormaPago.required'		=>'Es necesario seleccionar la Forma de Pago.',
+		]);
+
+		if($validator->fails()){
+			return redirect()->back()->withInput()->withErrors($validator->messages());
+		}
+
+		/*
+		INSERT INTO Dinero (
+		  Empresa,			Mov,			FechaEmision,		UltimoCambio,
+		  Concepto,			Moneda,			TipoCambio,			Referencia,
+		  Usuario,			Estatus,		Directo,			CtaDinero, 
+		  CtaDineroDestino, ConDesglose,	Importe,			FormaPago,	FechaProgramada,
+		  Sucursal,			SucursalOrigen,	TipoCambioDestino,	Prioridad,	TasaDias
+		)
+		VALUES (
+		  'ASSIS',		'Corte Caja',	'14/10/2015 00:00:00',	'14/10/2015 13:30:17',
+		  NULL,			'Pesos',		1.0,					NULL,  
+		  'AQUIJANO',	'SINAFECTAR',	1,						'CJAGE01',
+		  'BBVA0667',	0,				100.0,					'Efectivo',	'14/10/2015 13:25:27',
+		  0,			0,				1.0,					'Normal',	360
+		)
+		*/
+		$dinero->fill($dineroInput);
+
+		$user = \Auth::user();
+		$nowDate = Carbon::now()->format('d/m/Y');
+
+		$dinero->Empresa 			= $user->getSelectedCompany();
+		$dinero->Mov 				= $dinero->tipo_movimiento;		// Depende de la cuenta destino(CtaDineroDestino)
+		$dinero->FechaEmision 		= $nowDate;
+		$dinero->UltimoCambio 		= $nowDate;
+		$dinero->Concepto 			= $dinero->concepto_omision;	// Depende de (Mov)
+		$dinero->Moneda 			= config('cxc.default_currency');
+		$dinero->TipoCambio 		= $dinero->tipo_cambio_mon;		// Depende de la (Moneda)
+		//$dinero->Referencia 		= ;
+		$dinero->Usuario 			= $user->username;
+		$dinero->Estatus 			= 'SINAFECTAR';
+		$dinero->Directo 			= true;
+		$dinero->CtaDinero 			= $user->account;
+		$dinero->ConDesglose 		= false;
+		$dinero->FechaProgramada 	= $nowDate;
+		$dinero->Sucursal 			= $user->getSelectedOffice();
+		$dinero->SucursalOrigen 	= $user->getSelectedOffice();
+		$dinero->TipoCambioDestino	= $dinero->tipo_cambio_cta_destino;
+		$dinero->Prioridad 			= 'Normal';
+		$dinero->TasaDias 			= 360;
+
+		$dinero->save();
+
+
+		$action = \Input::get('action');
+
+		switch ($action) {
+			case 'afectar':
+				afectar($dinero->ID);
+				//return redirect('corteCaja/afectar');
+				break;	 
+			default:
+				$message = new \stdClass();
+				$message->type = 'INFO';
+				$message->description = 'Movimiento guardado.';
+				$message->code = $cxc->ID;
+				$message->reference = '';
+				return redirect('corteCaja')
+						->withMessage($message);
+				break;
+		}
+	}
+
+	public function getAfectar($ID){
+
+		//$ID = \Input::get('ID');
+
+		$user = \Auth::user();
+
+		//$din = Dinero::findOrFail($ID);
+		$din = Dinero::findOrNew($ID, Dinero::$COLUMN_NAMES);
+
+		$resultado = $din->afectar($user->username);
+		$mensaje = $din->crearMensaje($resultado);
+
+		return redirect('corteCaja')
+				->withMensaje($mensaje)
+				->with('DineroID',$ID);
 	}
 
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -24,6 +24,7 @@ Route::get('/cxc/movimiento/abrir','Cxc\MovController@showMovementSearch');
 Route::get('/embarques','Shipment\ShipmentController@showShipmentDocuments');
 
 Route::get('/corteCaja','CorteCaja\CorteCajaController@showCorteCaja');
+Route::post('/corteCaja','CorteCaja\CorteCajaController@postGuardar');
 
 Route::get('/cxc/movimiento/mov/{movID}/calculadora/{row}','UtileriesController@showCalculator');
 
@@ -33,6 +34,7 @@ Route::controllers([
 	'cxc/cliente' => 'Cxc\ClientController',
 	'cxc/documento' => 'Cxc\DocumentController',
 	//'utileries' => 'UtileriesController',
-	'embarques' => 'Shipment\ShipmentController'
+	'embarques' => 'Shipment\ShipmentController',
+	'corteCaja' => 'CorteCaja\CorteCajaController',
 ]);
 

--- a/config/cortecaja.php
+++ b/config/cortecaja.php
@@ -1,0 +1,13 @@
+<?php 
+	/*
+	 * Configuraciones para el módulo de Corte de Caja.
+	 */
+return [
+
+	'mov_corte_en_banco' 		=> 'TM Corte Caja', // (DIN.C)
+	'mov_corte_en_caja'  		=> 'TM Ent Valores a Caj', //(DIN.TC)
+	
+	//
+	//'concepto_corte_caja' 		=> null,
+	//'concepto_corte_tm_en_caja' => 'Corte de Caja',
+];

--- a/resources/views/corteDeCaja/corteCaja.blade.php
+++ b/resources/views/corteDeCaja/corteCaja.blade.php
@@ -64,11 +64,11 @@
 							<a id="printMov" style="display:inline-block" href="#">
 								<img height="30px" src="{{asset('img/print.png')}}">
 							</a-->
-							<a id="affectMov" style="display:inline-block" href="#">
+							<a id="afectar" style="display:inline-block" href="#">
 								<img height="30px" src="{{asset('img/affect.ico')}}">
 							</a>
 							
-							<a id="affectMov" style="display:inline-block" href="#">
+							<a id="reporte" style="display:inline-block" href="#">
 								<img height="30px" src="{{asset('img/reporteCorteCaja.ico')}}">
 							</a>
 							<!--a id="cancelMov" style="display:inline-block" href="#">
@@ -103,7 +103,13 @@
 								<a href="{{ url('/') }}" class="btn btn-primary btn-block" role="button">Regresar</a>
 							</div>
 							<br><br-->
-							{!! Form::open() !!}
+							@if ( \Session::has('mensaje') )
+								<div class="alert alert-{{ \Session::get('mensaje')->tipo }} alert-dismissible">
+									<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+									{!! \Session::get('mensaje')->mensaje !!}
+								</div>
+							@endif
+							{!! Form::model($din,['id'=>'CorteCajaForm']) !!}
 							  
 							  <div class="form-group">
 							    <label class="col-sm-offset-1 col-sm-3 control-label" for="saldo">Saldo Inicial:</label>
@@ -158,6 +164,7 @@
 							  	<button type="submit" class="btn btn-default" style="a:center;">Afectar?</button>
 							  	</div>
 							  </div-->
+							  {!! Form::hidden('ID',null,['id'=>'ID']) !!}
 							{!! Form::close() !!}
 						</div>
 					</div>
@@ -177,7 +184,10 @@
 
 		$('#saldo').val(moneyFormatForNumbers(saldo));
 
+		$('#afectar').click(function(){
 
+			$('#CorteCajaForm').submit();
+		});
 	</script>
 
 </body>


### PR DESCRIPTION
Se crearon los métodos para:
Obtener el tipo de movimiento dependiendo de la cuenta destino.
Obtener el concepto por omisión de los movimientos.
Afectar los movimientos del módulo Dinero.
Formatear el mensaje que devuelve el método afectar para mostrarlo en la
vista.
